### PR TITLE
Created an Object called Manager to encapsulate the channel and timer logic

### DIFF
--- a/connection/manager.go
+++ b/connection/manager.go
@@ -1,0 +1,65 @@
+package connection
+
+import (
+	"sync"
+	"time"
+)
+
+type Manager struct {
+	done      chan struct{}
+	reconnect chan bool
+	mutex     sync.Mutex
+	value     interface{}
+}
+
+func (self *Manager) WithLock(callBack func()) {
+	self.mutex.Lock()
+	callBack()
+	self.mutex.Unlock()
+}
+
+func (self *Manager) Signal() {
+	self.reconnect <- true
+}
+
+func (self *Manager) Begin(callBack func() bool, waitTime time.Duration) {
+	//fmt.Printf("Begin()\n")
+	self.reconnect = make(chan bool)
+	self.done = make(chan struct{})
+
+	var attemptedConnect sync.WaitGroup
+
+	go func() {
+		var once sync.Once
+		attemptedConnect.Add(1)
+
+		for {
+			var timer <-chan time.Time
+
+			select {
+			case <-self.reconnect:
+				goto connect
+			case <-timer:
+				goto connect
+			case <-self.done:
+				return
+			}
+		connect:
+			// Attempt to connect, if we fail to connect, set a timer to try again
+			if !callBack() {
+				timer = time.NewTimer(waitTime).C
+			}
+			once.Do(func() { attemptedConnect.Done() })
+		}
+	}()
+
+	// Send the first connect signal
+	self.Signal()
+	// Attempt to connect at least once before we leave
+	attemptedConnect.Wait()
+}
+
+func (self *Manager) End() {
+	//fmt.Printf("Close()\n")
+	close(self.done)
+}

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -43,7 +43,7 @@ func (self *KafkaProducer) Send(msg models.QueueMessage) error {
 	if err != nil {
 		if err == sarama.ErrBrokerNotAvailable || err == sarama.ErrClosedClient {
 			// Signal We should reconnect
-			self.ctx.SignalReconnect()
+			self.ctx.Signal()
 		}
 		return err
 	}
@@ -59,7 +59,7 @@ func (self *KafkaProducer) Get(payload []byte) error {
 	if err != nil {
 		if err == sarama.ErrBrokerNotAvailable || err == sarama.ErrClosedClient {
 			// Signal We should reconnect
-			self.ctx.SignalReconnect()
+			self.ctx.Signal()
 		}
 		return err
 	}
@@ -75,5 +75,5 @@ func (self *NilProducer) Send(msg models.QueueMessage) error {
 
 // Returns the Kafka interface from our context
 func GetProducer(ctx context.Context) Producer {
-	return GetProducerManager(ctx).Get()
+	return GetProducerManager(ctx).GetProducer()
 }

--- a/store/store.go
+++ b/store/store.go
@@ -108,7 +108,7 @@ func (self *RethinkStore) UpdateMessage(id string, fields map[string]interface{}
 }
 
 func (self *RethinkStore) SignalReconnect() {
-	self.manager.SignalReconnect()
+	self.manager.Signal()
 }
 
 func (self *RethinkStore) IsConnected() bool {

--- a/worker.go
+++ b/worker.go
@@ -54,7 +54,7 @@ func (self *Worker) Start() {
 					"type":   "kafka",
 					"method": "Start()",
 				}).Error("Received Error - ", err.Error())
-				self.consumer.SignalReconnect()
+				self.consumer.Signal()
 			case <-self.done:
 				return
 			}


### PR DESCRIPTION
As suggested by @obukhov-sergey in #1 this is an attempt to simplify the connection manager implementation by encapsulating the channel and timer logic into a separate object.

A concrete example would look like this.

``` go
type RethinkManager struct {
    *connection.Manager
    session *gorethink.Session
}

func NewManager() *RethinkManager {
    me := &Manager{
        &connection.Manager{},
    }
    me.Start()
    return me
}

func (self *RethinkManager) GetSession() (result *gorethink.Session) {
    self.WithLock(func() {
        result = self.session
    })
    return
}

func (self *RethinkManager) Start() {
    // run connect(), if it fails try again every 2 seconds
    self.Begin(self.connect, time.Second*2)
}

func (self *RethinkManager) Stop() {
    session := self.GetSession()
    if session != nil {
        session.Close()
    }
    self.End()
}

func (self *RethinkManager) connect() bool {
    // Connect to rethink and return true if successful
}
```
